### PR TITLE
Implement SessionResetter interface

### DIFF
--- a/chanGroup_test.go
+++ b/chanGroup_test.go
@@ -1,0 +1,22 @@
+package hotload
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = XDescribe("Driver", func() {
+	Context("chanGroup", func() {
+		It("Should work", func() {
+			//chanGroup{
+			//	value:     "",
+			//	values:    nil,
+			//	parentCtx: nil,
+			//	ctx:       nil,
+			//	cancel:    nil,
+			//	sqlDriver: nil,
+			//	mu:        sync.RWMutex{},
+			//	conns:     nil,
+			//}
+		})
+	})
+})

--- a/conn.go
+++ b/conn.go
@@ -8,11 +8,12 @@ import (
 // managedConn wraps a sql/driver.Conn so that it can be closed by
 // a supervising context.
 type managedConn struct {
-	ctx  context.Context
-	conn driver.Conn
+	ctx   context.Context
+	conn  driver.Conn
+	reset bool
 }
 
-func newManagedConn(ctx context.Context, conn driver.Conn) driver.Conn {
+func newManagedConn(ctx context.Context, conn driver.Conn) *managedConn {
 	return &managedConn{
 		ctx:  ctx,
 		conn: conn,
@@ -93,6 +94,14 @@ func (c *managedConn) IsValid() bool {
 		return true
 	}
 	return s.IsValid()
+}
+
+func (c *managedConn) ResetSession(ctx context.Context) error {
+	if c.reset {
+		return driver.ErrBadConn
+	}
+
+	return nil
 }
 
 func (c *managedConn) Close() error {

--- a/driver_test.go
+++ b/driver_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func getDriverFromSqlMock() driver.Driver {
-	littleBuddy, mockyMoo, _ := sqlmock.NewWithDSN("user=pqgotest dbname=pqgotest sslmode=verify-full")
-	mockyPoo = mockyMoo
+	littleBuddy, mock, _ := sqlmock.NewWithDSN("user=pqgotest dbname=pqgotest sslmode=verify-full")
+	mockDriver = mock
 	return littleBuddy.Driver()
 }
 
@@ -22,7 +22,7 @@ func getRandomDriver() driver.Driver {
 	return db.Driver()
 }
 
-var mockyPoo sqlmock.Sqlmock
+var mockDriver sqlmock.Sqlmock
 var configFile string
 var configFileDir string
 
@@ -114,9 +114,9 @@ var _ = Describe("Driver", func() {
 		//	// Open dat
 		//	// Do a thing
 		//	// change connection file
-		//	mockyPoo.ExpectBegin()
-		//	mockyPoo.ExpectExec("SELECT 1")
-		//	mockyPoo.ExpectCommit()
+		//	mockDriver.ExpectBegin()
+		//	mockDriver.ExpectExec("SELECT 1")
+		//	mockDriver.ExpectCommit()
 		//	tx, err := db.Begin()
 		//	Expect(err).ToNot(HaveOccurred())
 		//	tx.Exec("SELECT 1")
@@ -124,7 +124,7 @@ var _ = Describe("Driver", func() {
 		//	Expect(err).ToNot(HaveOccurred())
 		//	go func () {
 		//		tx.Commit()
-		//		Expect(mockyPoo.ExpectationsWereMet()).ToNot(HaveOccurred())
+		//		Expect(mockDriver.ExpectationsWereMet()).ToNot(HaveOccurred())
 		//	}()
 		//})
 	})

--- a/driver_test.go
+++ b/driver_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func getDriverFromSqlMock() driver.Driver {
-	littleBuddy, _, _ := sqlmock.NewWithDSN("user=pqgotest dbname=pqgotest sslmode=verify-full")
+	littleBuddy, mockyMoo, _ := sqlmock.NewWithDSN("user=pqgotest dbname=pqgotest sslmode=verify-full")
+	mockyPoo = mockyMoo
 	return littleBuddy.Driver()
 }
 
@@ -21,7 +22,9 @@ func getRandomDriver() driver.Driver {
 	return db.Driver()
 }
 
+var mockyPoo sqlmock.Sqlmock
 var configFile string
+var configFileDir string
 
 var _ = Describe("Driver", func() {
 	BeforeSuite(func() {
@@ -36,6 +39,7 @@ var _ = Describe("Driver", func() {
 		var err error
 		configFile, err = os.Getwd()
 		Expect(err).ToNot(HaveOccurred())
+		configFileDir = configFile + "/testdata/"
 		configFile += "/testdata/myconfig.txt"
 	})
 
@@ -101,5 +105,27 @@ var _ = Describe("Driver", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("missing protocol scheme"))
 		})
+
+		//It("Should close my connection when the connection information changes", func() {
+		//	db, err := sql.Open("hotload", "fsnotify://sqlmock"+configFileDir+"urconfig.txt")
+		//	Expect(err).ToNot(HaveOccurred())
+		//
+		//	Expect(db.Ping()).ToNot(HaveOccurred())
+		//	// Open dat
+		//	// Do a thing
+		//	// change connection file
+		//	mockyPoo.ExpectBegin()
+		//	mockyPoo.ExpectExec("SELECT 1")
+		//	mockyPoo.ExpectCommit()
+		//	tx, err := db.Begin()
+		//	Expect(err).ToNot(HaveOccurred())
+		//	tx.Exec("SELECT 1")
+		//	err = ioutil.WriteFile(configFileDir+"urconfig.txt", []byte("user=pqgotest dbname=pqgotestorooni sslmode=verify-full"), 0644)
+		//	Expect(err).ToNot(HaveOccurred())
+		//	go func () {
+		//		tx.Commit()
+		//		Expect(mockyPoo.ExpectationsWereMet()).ToNot(HaveOccurred())
+		//	}()
+		//})
 	})
 })

--- a/testdata/config.txt
+++ b/testdata/config.txt
@@ -1,0 +1,1 @@
+user=pqgotest dbname=pqgotest sslmode=verify-full


### PR DESCRIPTION
This interface allows the driver to tell database/sql when a connection needs to be discarded from the pool. 
These methods in this hierarchy end up calling db.conn which requests a connection from the pool and asks the driver if a reset is needed. thus flushing the connection pool. 