### PR TITLE
allow extra options to be registered during driver registration

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,9 +17,11 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
     - uses: engineerd/setup-kind@v0.5.0
       with:
-        version: "v0.10.0"
+        version: "v0.11.1"
     - name: Integration Tests
-      run: make ci-integration-tests
+      run: |
+        kubectl cluster-info
+        make ci-integration-tests

--- a/driver_internal_test.go
+++ b/driver_internal_test.go
@@ -1,0 +1,75 @@
+package hotload
+
+import (
+	"testing"
+)
+
+func Test_mergeConnectionStringOptions(t *testing.T) {
+	type args struct {
+		dsn     string
+		options map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "empty",
+			args: args{
+				dsn:     "",
+				options: nil,
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "bad dsn with no options",
+			args: args{
+				dsn:     "bad dsn",
+				options: nil,
+			},
+			want:    "bad dsn",
+			wantErr: false,
+		},
+		{
+			name: "bad dsn with options",
+			args: args{
+				dsn:     "bad dsn",
+				options: map[string]string{"a": "b"},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "good dsn with no options",
+			args: args{
+				dsn: "postgres://localhost:5432/postgres?sslmode=disable",
+			},
+			want:    "postgres://localhost:5432/postgres?sslmode=disable",
+			wantErr: false,
+		},
+		{
+			name: "good dsn with options",
+			args: args{
+				dsn:     "postgres://localhost:5432/postgres?sslmode=disable",
+				options: map[string]string{"disable_cache": "true"},
+			},
+			want:    "postgres://localhost:5432/postgres?disable_cache=true&sslmode=disable",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mergeConnectionStringOptions(tt.args.dsn, tt.args.options)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mergeConnectionStringOptions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("mergeConnectionStringOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -3,12 +3,13 @@ package hotload_test
 import (
 	"database/sql"
 	"database/sql/driver"
+	"os"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/infobloxopen/hotload"
 	"github.com/infobloxopen/hotload/fsnotify"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"os"
 )
 
 func getDriverFromSqlMock() driver.Driver {


### PR DESCRIPTION
This change allows extra driver options to be passed to the underlying DSN. This makes the assumption that the underlying DSN is a URL based DSN and these options can be added as query parameters.