### PR TITLE
remove connection after close

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -128,7 +128,7 @@ var _ = Describe("PrometheusMetrics", func() {
 	`
 
 	It("Should emit the correct metrics", func() {
-		mc := newManagedConn(context.Background(), mockDriverConn{})
+		mc := newManagedConn(context.Background(), mockDriverConn{}, nil)
 
 		ctx := ContextWithExecLabels(context.Background(), map[string]string{"grpc_method": "method_1", "grpc_service": "service_1"})
 

--- a/driver.go
+++ b/driver.go
@@ -272,10 +272,21 @@ func (cg *chanGroup) Open() (driver.Conn, error) {
 		return conn, err
 	}
 
-	manConn := newManagedConn(cg.ctx, conn)
+	manConn := newManagedConn(cg.ctx, conn, cg.remove)
 	cg.conns = append(cg.conns, manConn)
 
 	return manConn, nil
+}
+
+func (cg *chanGroup) remove(conn *managedConn) {
+	cg.mu.Lock()
+	defer cg.mu.Unlock()
+	for i, c := range cg.conns {
+		if c == conn {
+			cg.conns = append(cg.conns[:i], cg.conns[i+1:]...)
+			return
+		}
+	}
 }
 
 func (cg *chanGroup) parseValues(vs url.Values) {


### PR DESCRIPTION
`chanGroup` was preserving references to closed connections, which caused a noticeable memory leak. It was more apparent in cases where there were bursts of many threads and no open connection limit (default) and with drivers that allocate larger buffers per connection.