### PR TITLE
clean extra slashes from path

### DIFF
--- a/fsnotify/filewatcher.go
+++ b/fsnotify/filewatcher.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -116,6 +117,7 @@ func (s *Strategy) setVal(pth string, val string) {
 
 // Watch implements the hotload.Strategy interface.
 func (s *Strategy) Watch(ctx context.Context, pth string, options url.Values) (value string, values <-chan string, err error) {
+	pth = path.Clean(pth)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	// if this is the first time this strategy is called, initialize ourselves

--- a/fsnotify/filewatcher_test.go
+++ b/fsnotify/filewatcher_test.go
@@ -167,6 +167,26 @@ var _ = Describe("FileWatcher", func() {
 				os.Remove(args.pth)
 			},
 		}),
+		Entry("extra slash in path", test{
+			setup: func(args *args) {
+				f, _ := os.CreateTemp("", "unittest_")
+				f.Write([]byte("a"))
+				args.pth = "/" + f.Name()
+				f.Close()
+			},
+			wantErr: false,
+			post: func(args *args, value string, values <-chan string) error {
+				if value != "a" {
+					return fmt.Errorf("expected 'a' got %v", value)
+				}
+				os.WriteFile(args.pth, []byte("b"), 0660)
+				assertStringFromChannel("wating for update b", "b", values)
+				return nil
+			},
+			tearDown: func(args *args) {
+				os.Remove(args.pth)
+			},
+		}),
 		Entry("a, rm a, create b", test{
 			setup: func(args *args) {
 				f, _ := os.CreateTemp("", "unittest_")


### PR DESCRIPTION
`os.ReadFile()` will normalize oddities in paths like `//var/run/db` or `/var/./run/db`. The same normalization should be applied in the lookup map.