### PR TITLE
PTOCP-2248: Fix fsnotify log, refactor logger framework

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -77,8 +77,6 @@ var (
 	mu         sync.RWMutex
 	sqlDrivers = make(map[string]*driverInstance)
 	strategies = make(map[string]Strategy)
-
-	log logger.Logger
 )
 
 type driverInstance struct {
@@ -337,16 +335,12 @@ func (h *hdriver) Open(name string) (driver.Conn, error) {
 	return cgroup.Open()
 }
 
+// Deprecated: Use logger.WithLogger() instead, retained for backwards-compatibility only
 func WithLogger(l logger.Logger) {
-	log = l
-	if log == nil {
-		log = logger.DefaultLogger
-	}
+	logger.WithLogger(l)
 }
 
+// Deprecated: Use logger.GetLogger() instead, retained for backwards-compatibility only
 func GetLogger() logger.Logger {
-	if log == nil {
-		return logger.DefaultLogger
-	}
-	return log
+	return logger.GetLogger()
 }

--- a/fsnotify/filewatcher.go
+++ b/fsnotify/filewatcher.go
@@ -11,6 +11,7 @@ import (
 
 	rfsnotify "github.com/fsnotify/fsnotify"
 	"github.com/infobloxopen/hotload"
+	"github.com/infobloxopen/hotload/logger"
 	"github.com/pkg/errors"
 )
 
@@ -19,7 +20,6 @@ func init() {
 }
 
 var resyncPeriod = time.Second * 2
-var log = hotload.GetLogger()
 
 // NewStrategy implements a hotload strategy that monitors config changes
 // in a file using fsnotify.
@@ -53,6 +53,7 @@ func readConfigFile(path string) (v []byte, err error) {
 }
 
 func resync(w watcher, pth string) (string, error) {
+	log := logger.GetLogger()
 	log("fsnotify: Path Name-Resync ", pth)
 	err := w.Remove(pth)
 	if err != nil && !errors.Is(err, rfsnotify.ErrNonExistentWatch) {
@@ -66,6 +67,7 @@ func resync(w watcher, pth string) (string, error) {
 }
 
 func (s *Strategy) run() {
+	log := logger.GetLogger()
 	failedPaths := make(map[string]struct{})
 	for {
 		select {
@@ -102,6 +104,7 @@ func (s *Strategy) run() {
 }
 
 func (s *Strategy) setVal(pth string, val string) {
+	log := logger.GetLogger()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.paths[pth]; !ok {
@@ -117,6 +120,7 @@ func (s *Strategy) setVal(pth string, val string) {
 
 // Watch implements the hotload.Strategy interface.
 func (s *Strategy) Watch(ctx context.Context, pth string, options url.Values) (value string, values <-chan string, err error) {
+	log := logger.GetLogger()
 	pth = path.Clean(pth)
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -5,3 +5,22 @@ type Logger func(...interface{})
 
 // DefaultLogger is a no-op logger function that does nothing
 var DefaultLogger Logger = func(args ...interface{}) {}
+
+// stdLogger is the standard global logger
+var stdLogger Logger = DefaultLogger
+
+// WithLogger sets the standard logger
+func WithLogger(l Logger) {
+	stdLogger = l
+	if stdLogger == nil {
+		stdLogger = DefaultLogger
+	}
+}
+
+// GetLogger gets the standard logger
+func GetLogger() Logger {
+	if stdLogger == nil {
+		return DefaultLogger
+	}
+	return stdLogger
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,34 @@
+package logger
+
+import (
+	"fmt"
+	"testing"
+)
+
+// This is initialized to DefaultLogger at init-time!
+var logger Logger = GetLogger()
+
+func TestLogger(t *testing.T) {
+	logCount := 0
+	WithLogger(func(args ...any) {
+		logCount = logCount + 1
+		fmt.Println(args...)
+	})
+
+	// Call package logger here,
+	// which is initialized to DefaultLogger at init-time!
+	logger("value of pi", 3.14159)
+	if logCount == 0 {
+		t.Logf("verified logCount was not updated because replacement logger was not called")
+	} else {
+		t.Errorf("logCount should be 0, logCount=%d", logCount)
+	}
+
+	// Declare local logger var that hides package logger,
+	// and initialize with current Logger.
+	logger := GetLogger()
+	logger("value of pi", 3.14159)
+	if logCount != 1 {
+		t.Errorf("logCount should be 1, logCount=%d", logCount)
+	}
+}


### PR DESCRIPTION
WithLogger() and GetLogger() really belongs in logger pkg, not in hotload pkg.  That way any use of With/GetLogger() doesn't depend on hotload pkg, and helps to prevent potential future circular import dependencies.