### PR TITLE
PTOCP-2468: Fix filewatcher event operation mask comparison

### DIFF
--- a/fsnotify/filewatcher.go
+++ b/fsnotify/filewatcher.go
@@ -72,8 +72,8 @@ func (s *Strategy) run() {
 	for {
 		select {
 		case e := <-s.watcher.GetEvents():
-			log("fsnotify: Path Name-Run ", e.Name)
-			if e.Op != rfsnotify.Write && e.Op != rfsnotify.Remove {
+			log("fsnotify: Path Name-Run: got event: ", e.String())
+			if !e.Has(rfsnotify.Write) && !e.Has(rfsnotify.Remove) {
 				continue
 			}
 


### PR DESCRIPTION
fsnotify event-operation is a bitmask, so change event-operation value comparison to event-operation bitmask comparison.