### PR TITLE
feat: support key=value DSN format in WithDriverOptions

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -53,6 +53,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -95,9 +96,12 @@ type driverInstance struct {
 
 type driverOption func(*driverInstance)
 
-// WithDriverOptions allows you to specify query parameters to the underlying driver.
-// The underlying driver must support URL style connection strings. The given options
-// are appended to the connection string when a connection is opened.
+// WithDriverOptions allows you to specify extra parameters for the underlying
+// driver. The given options are merged into the connection string when a
+// connection is opened. For URL-format DSNs (e.g. postgres://host/db) the
+// options are appended as query parameters. For key=value-format DSNs (e.g.
+// "host=localhost dbname=mydb") the options are appended as key=value pairs
+// with proper quoting per PostgreSQL libpq conventions.
 func WithDriverOptions(options map[string]string) driverOption {
 	return func(d *driverInstance) {
 		if d.options == nil {
@@ -375,18 +379,35 @@ func mergeConnStringOptions(dsn string, options map[string]string) (string, erro
 		return dsn, nil
 	}
 	u, err := url.ParseRequestURI(dsn)
-	if err != nil {
-		return "", fmt.Errorf("unable to parse connection string when specifying extra driver options: %v", err)
+	if err == nil {
+		// URI format (e.g. postgres://user:pass@host:5432/db?sslmode=disable)
+		values, err := url.ParseQuery(u.RawQuery)
+		if err != nil {
+			return "", fmt.Errorf("unable to parse query options in connection string when specifying extra driver options: %v", err)
+		}
+		for k, v := range options {
+			values.Set(k, v)
+		}
+		u.RawQuery = values.Encode()
+		return u.String(), nil
 	}
-	values, err := url.ParseQuery(u.RawQuery)
-	if err != nil {
-		return "", fmt.Errorf("unable to parse query options in connection string when specifying extra driver options: %v", err)
-	}
+	// Key=value format (e.g. "host=localhost port=5432 user=u password=p dbname=db sslmode=disable")
 	for k, v := range options {
-		values.Set(k, v)
+		dsn += " " + k + "=" + quoteConnStringValue(v)
 	}
-	u.RawQuery = values.Encode()
-	return u.String(), nil
+	return dsn, nil
+}
+
+// quoteConnStringValue quotes a value for use in a PostgreSQL key=value
+// connection string if it is empty or contains characters that require quoting
+// (spaces, single quotes, or backslashes), per libpq conventions.
+func quoteConnStringValue(v string) string {
+	if v == "" || strings.ContainsAny(v, " '\\\n") {
+		v = strings.ReplaceAll(v, "\\", "\\\\")
+		v = strings.ReplaceAll(v, "'", "\\'")
+		return "'" + v + "'"
+	}
+	return v
 }
 
 func (cg *chanGroup) Open() (driver.Conn, error) {

--- a/driver_internal_test.go
+++ b/driver_internal_test.go
@@ -90,13 +90,13 @@ func Test_mergeConnStringOptions(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "bad dsn with options",
+			name: "key=value dsn with options",
 			args: args{
-				dsn:     "bad dsn",
-				options: map[string]string{"a": "b"},
+				dsn:     "host=localhost port=5432 dbname=mydb sslmode=disable",
+				options: map[string]string{"application_name": "my-app"},
 			},
-			want:    "",
-			wantErr: true,
+			want:    "host=localhost port=5432 dbname=mydb sslmode=disable application_name=my-app",
+			wantErr: false,
 		},
 		{
 			name: "good dsn with no options",
@@ -115,6 +115,27 @@ func Test_mergeConnStringOptions(t *testing.T) {
 			want:    "postgres://localhost:5432/postgres?disable_cache=true&sslmode=disable",
 			wantErr: false,
 		},
+		{
+			// Reproduces the CrashLoopBackOff observed in dns-config-svc pods.
+			// db-controller provides DSN in key=value format and the password
+			// contains URI-special characters (&, <) that break url.ParseRequestURI.
+			name: "key=value dsn with special chars in password",
+			args: args{
+				dsn:     `host=mydb.cluster.rds.amazonaws.com port=5432 user=nstar_user password=Fhl&kB<U4eY87z. dbname=mydb sslmode=require`,
+				options: map[string]string{"application_name": "dns-config-svc"},
+			},
+			want:    `host=mydb.cluster.rds.amazonaws.com port=5432 user=nstar_user password=Fhl&kB<U4eY87z. dbname=mydb sslmode=require application_name=dns-config-svc`,
+			wantErr: false,
+		},
+		{
+			name: "key=value dsn option value with spaces is quoted",
+			args: args{
+				dsn:     "host=localhost dbname=testdb",
+				options: map[string]string{"application_name": "my service"},
+			},
+			want:    "host=localhost dbname=testdb application_name='my service'",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -125,6 +146,29 @@ func Test_mergeConnStringOptions(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("mergeConnStringOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_quoteConnStringValue(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "simple"},
+		{"dns-config-svc", "dns-config-svc"},
+		{"has space", "'has space'"},
+		{"", "''"},
+		{"has'quote", `'has\'quote'`},
+		{`has\backslash`, `'has\\backslash'`},
+		{"Fhl&kB<U4eY87z.", "Fhl&kB<U4eY87z."}, // URI-special chars don't need quoting in key=value
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := quoteConnStringValue(tt.input)
+			if got != tt.want {
+				t.Errorf("quoteConnStringValue(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

`mergeConnStringOptions` uses `url.ParseRequestURI` to parse the DSN before merging driver options as URL query parameters. This requires the DSN to be in URL format (`postgres://user:pass@host/db?sslmode=disable`).

When the DSN is in PostgreSQL **key=value format** (e.g. `host=localhost port=5432 user=u password=p dbname=db sslmode=disable`) — commonly provided by database controllers like [db-controller](https://github.com/infobloxopen/db-controller) — and the password contains URI-special characters (`&`, `<`, etc.), `url.ParseRequestURI` fails with:

```
unable to parse connection string when specifying extra driver options:
  parse "host=... password=Fhl&kB<U4eY87z. dbname=... sslmode=require": invalid URI for request
```

This was observed in production causing `CrashLoopBackOff` on Kubernetes pods after `WithDriverOptions` was used to inject `application_name`.

## Fix

Detect the DSN format at merge time:
- **URL-format DSNs**: merge options as URL query parameters (existing behavior, unchanged)
- **Key=value-format DSNs**: append options as `key=value` pairs with proper single-quoting per PostgreSQL libpq conventions

Added `quoteConnStringValue` helper that quotes values containing spaces, single quotes, or backslashes.

## Tests

- Updated `Test_mergeConnStringOptions`: replaced the `"bad dsn with options"` error case with key=value success cases, including the **exact crash scenario from production** (password with `&` and `<`)
- Added `Test_quoteConnStringValue` covering edge cases (empty, spaces, quotes, backslashes, URI-special chars)